### PR TITLE
Fix compile failure on alpine linux

### DIFF
--- a/esajpip/esajpip/src/app_info.cc
+++ b/esajpip/esajpip/src/app_info.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#include <fcntl.h>
 
 #ifndef _SC_AVPHYS_PAGES
 #include <sys/sysctl.h>


### PR DESCRIPTION
I was getting this compilation error on alpine linux.
Issue was just missing the `include <fcntl.h>`

It compiles with this patch.

```
[ 89%] Building CXX object esajpip/CMakeFiles/esajpip.dir/esajpip/src/jpip/jpip.cc.o
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc: In member function 'bool AppInfo::Init()':
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:24:18: error: aggregate 'AppInfo::Init()::flock fl' has incomplete type and cannot be defined
   24 |     struct flock fl;
      |                  ^~
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:26:17: error: 'F_WRLCK' was not declared in this scope
   26 |     fl.l_type = F_WRLCK;
      |                 ^~~~~~~
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:34:38: error: 'O_WRONLY' was not declared in this scope
   34 |     if ((lock_file = open(LOCK_FILE, O_WRONLY | O_CREAT, 0666)) != -1) {
      |                                      ^~~~~~~~
[ 91%] Building CXX object esajpip/CMakeFiles/esajpip.dir/esajpip/src/jpip/request.cc.o
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:34:49: error: 'O_CREAT' was not declared in this scope; did you mean 'IPC_CREAT'?
   34 |     if ((lock_file = open(LOCK_FILE, O_WRONLY | O_CREAT, 0666)) != -1) {
      |                                                 ^~~~~~~
      |                                                 IPC_CREAT
[ 92%] Building CXX object esajpip/CMakeFiles/esajpip.dir/esajpip/src/net/socket.cc.o
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:34:22: error: 'open' was not declared in this scope; did you mean 'pope'?
   34 |     if ((lock_file = open(LOCK_FILE, O_WRONLY | O_CREAT, 0666)) != -1) {
      |                      ^~~~
      |                      popen
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:35:41: error: 'F_SETLK' was not declared in this scope
   35 |         is_running_ = (fcntl(lock_file, F_SETLK, &fl) == -1);
      |                                         ^~~~~~~
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:35:24: error: 'fcntl' was not declared in this scope
   35 |         is_running_ = (fcntl(lock_file, F_SETLK, &fl) == -1);
      |                        ^~~~~
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc: In member function 'AppInfo& AppInfo::Update()':
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:71:22: error: aggregate 'AppInfo::Update()::flock fl' has incomplete type and cannot be defined
   71 |         struct flock fl;
      |                      ^~
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:73:21: error: 'F_WRLCK' was not declared in this scope
   73 |         fl.l_type = F_WRLCK;
      |                     ^~~~~~~
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:78:37: error: 'O_RDONLY' was not declared in this scope; did you mean 'SHM_RDONLY'?
   78 |         if ((lock = open(LOCK_FILE, O_RDONLY, 0666)) != -1) {
      |                                     ^~~~~~~~
      |                                     SHM_RDONLY
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:78:21: error: 'open' was not declared in this scope; did you mean 'pope'?
   78 |         if ((lock = open(LOCK_FILE, O_RDONLY, 0666)) != -1) {
      |                     ^~~~
      |                     popen
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:79:29: error: 'F_GETLK' was not declared in this scope
   79 |             if (fcntl(lock, F_GETLK, &fl) != -1)
      |                             ^~~~~~~
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:79:17: error: 'fcntl' was not declared in this scope
   79 |             if (fcntl(lock, F_GETLK, &fl) != -1)
      |                 ^~~~~
/esajpip-SWHV/esajpip/esajpip/src/app_info.cc:80:45: error: 'F_UNLCK' was not declared in this scope; did you mean 'F_ULOCK'?
   80 |                 is_running_ = (fl.l_type != F_UNLCK);
      |                                             ^~~~~~~
      |                                             F_ULOCK
make[2]: *** [esajpip/CMakeFiles/esajpip.dir/build.make:90: esajpip/CMakeFiles/esajpip.dir/esajpip/src/app_info.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:187: esajpip/CMakeFiles/esajpip.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```